### PR TITLE
Core 1462 handle json parse errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "presets": ["env", "stage-2"],
-  "plugins": ["babel-plugin-add-module-exports"]
+  "plugins": [
+    "babel-plugin-add-module-exports",
+    ["babel-plugin-transform-builtin-extend", {"globals": ["Error"]}]
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ unsubscribed |  | Fired when an unsubscription is acknowledged by the server.
 resending |  | Fired when the subscription starts resending.
 resent |  | Fired after `resending` when the subscription has finished resending.
 no_resend |  | Fired after `resending` in case there was nothing to resend.
+error | Error object | Reports errors, for example problems with message content 
 
 ### Logging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -263,14 +263,12 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
       "version": "1.3.2",
@@ -474,7 +472,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -732,7 +729,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -820,6 +816,15 @@
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
         "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-builtin-extend": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-builtin-extend/-/babel-plugin-transform-builtin-extend-1.1.2.tgz",
+      "integrity": "sha1-Xpb+z1i4+h7XTvytiEdbKvPJEW4=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1246,7 +1251,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -1259,7 +1263,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
@@ -1276,7 +1279,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1287,7 +1289,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
@@ -1298,8 +1299,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1654,7 +1654,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -2365,8 +2364,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escope": {
       "version": "3.6.0",
@@ -2725,8 +2723,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -4001,8 +3998,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "5.0.0",
@@ -4051,7 +4047,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -4313,7 +4308,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -4624,8 +4618,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.11.0",
@@ -4817,8 +4810,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -4842,7 +4834,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -6609,7 +6600,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -6635,8 +6625,7 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "table": {
       "version": "4.0.2",
@@ -6744,8 +6733,7 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "JavaScript client library for Streamr",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
+    "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-runtime": "^6.26.0",
     "debug": "^3.1.0",
     "eventemitter3": "^3.0.1",

--- a/src/Connection.js
+++ b/src/Connection.js
@@ -52,8 +52,13 @@ module.exports = class Connection extends EventEmitter {
             }
 
             this.socket.onmessage = (messageEvent) => {
-                const decoded = decodeBrowserWrapper(messageEvent.data)
-                this.emit(decoded.type, decodeMessage(decoded.type, decoded.msg), decoded.subId)
+                try {
+                    const decodedWrapper = decodeBrowserWrapper(messageEvent.data)
+                    const decodedMessage = decodeMessage(decodedWrapper.type, decodedWrapper.msg)
+                    this.emit(decodedWrapper.type, decodedMessage, decodedWrapper.subId)
+                } catch (err) {
+                    this.emit('error', err)
+                }
             }
         }
     }

--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -199,4 +199,8 @@ export default class Subscription extends EventEmitter {
         debug(`Subscription: Stream ${this.streamId} resending: ${resending}`)
         this.resending = resending
     }
+
+    handleError(err) {
+        this.emit('error', err)
+    }
 }

--- a/src/errors/InvalidJsonError.js
+++ b/src/errors/InvalidJsonError.js
@@ -1,0 +1,8 @@
+module.exports = class InvalidJsonError extends Error {
+    constructor(streamId, jsonString, parseError) {
+        super(`Invalid JSON in stream ${streamId}: ${jsonString}. Error while parsing was: ${parseError}`)
+        this.streamId = streamId
+        this.jsonString = jsonString
+        this.parseError = parseError
+    }
+}

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -11,7 +11,6 @@ const debug = debugFactory('StreamrClient')
 const agentSettings = {
     keepAlive: true,
     keepAliveMsecs: 5000,
-    maxSockets: 1,
 }
 
 const agentByProtocol = {

--- a/src/rest/StreamEndpoints.js
+++ b/src/rest/StreamEndpoints.js
@@ -11,6 +11,7 @@ const debug = debugFactory('StreamrClient')
 const agentSettings = {
     keepAlive: true,
     keepAliveMsecs: 5000,
+    maxSockets: 1,
 }
 
 const agentByProtocol = {

--- a/test/unit/Protocol.spec.js
+++ b/test/unit/Protocol.spec.js
@@ -1,0 +1,31 @@
+import assert from 'assert'
+import * as Protocol from '../../src/Protocol'
+import InvalidJsonError from '../../src/errors/InvalidJsonError'
+
+describe('Protocol', () => {
+    describe('decodeMessage', () => {
+        it('returns messages untouched if they are not broadcast or unicast messages', () => {
+            const msg = {}
+            const result = Protocol.decodeMessage('unknown', msg)
+            assert(result === msg)
+        })
+
+        it('parses message content when the content type is json', () => {
+            const msg = [28, 'TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, 941516902, 941499898, 27, '{"valid": "json"}']
+            const result = Protocol.decodeMessage('b', msg)
+            assert.deepEqual(result.content, {
+                valid: 'json',
+            })
+        })
+
+        it('throws if the json is invalid', () => {
+            const msg = [28, 'TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, 941516902, 941499898, 27, '{"invalid\njson"}']
+            assert.throws(() => Protocol.decodeMessage('b', msg), (err) => {
+                assert(err instanceof InvalidJsonError)
+                assert.equal(err.streamId, 'TsvTbqshTsuLg_HyUjxigA')
+                assert.equal(err.jsonString, '{"invalid\njson"}')
+                return true
+            })
+        })
+    })
+})


### PR DESCRIPTION
When a message with an invalid json payload is encountered, the message handling fails gracefully and an `error` event is emitted on the relevant `Subscription`s listening to that stream.

Also cleaned up `StreamrClient.test.js` to conform to eslint rules.