### PR TITLE
Recover after messages that fail to parse

### DIFF
--- a/src/Protocol.js
+++ b/src/Protocol.js
@@ -13,6 +13,11 @@ messageTypesByCode.forEach((type, idx) => {
 
 const BYE_KEY = '_bye'
 
+// Slow, use only in exceptional situations
+function getField(fieldName, msg) {
+    return msg[fieldsByProtocolVersion[msg[0]].indexOf(fieldName)]
+}
+
 export const decodeBrowserWrapper = (rawMsg) => {
     const jsonMsg = JSON.parse(rawMsg)
     const version = jsonMsg[0]
@@ -42,7 +47,13 @@ export const decodeMessage = (type, message) => {
                     try {
                         result[fields[i]] = JSON.parse(message[i])
                     } catch (err) {
-                        throw new InvalidJsonError(result.streamId, message[i], err)
+                        throw new InvalidJsonError(
+                            result.streamId,
+                            message[i],
+                            err,
+                            getField('offset', message),
+                            getField('previousOffset', message),
+                        )
                     }
                 } else {
                     throw new Error(`Unknown content type: ${result.contentType}`)

--- a/src/errors/InvalidJsonError.js
+++ b/src/errors/InvalidJsonError.js
@@ -1,8 +1,10 @@
 module.exports = class InvalidJsonError extends Error {
-    constructor(streamId, jsonString, parseError) {
+    constructor(streamId, jsonString, parseError, offset, previousOffset) {
         super(`Invalid JSON in stream ${streamId}: ${jsonString}. Error while parsing was: ${parseError}`)
         this.streamId = streamId
         this.jsonString = jsonString
         this.parseError = parseError
+        this.offset = offset
+        this.previousOffset = previousOffset
     }
 }

--- a/test/unit/Protocol.spec.js
+++ b/test/unit/Protocol.spec.js
@@ -24,6 +24,8 @@ describe('Protocol', () => {
                 assert(err instanceof InvalidJsonError)
                 assert.equal(err.streamId, 'TsvTbqshTsuLg_HyUjxigA')
                 assert.equal(err.jsonString, '{"invalid\njson"}')
+                assert.equal(err.offset, 941516902)
+                assert.equal(err.previousOffset, 941499898)
                 return true
             })
         })

--- a/test/unit/Subscription.spec.js
+++ b/test/unit/Subscription.spec.js
@@ -1,0 +1,91 @@
+import assert from 'assert'
+import sinon from 'sinon'
+import Subscription from '../../src/Subscription'
+import InvalidJsonError from '../../src/errors/InvalidJsonError'
+
+describe('Subscription', () => {
+    describe('handleMessage', () => {
+        it('calls the message handler', (done) => {
+            const msg = {
+                offset: 1,
+                previousOffset: null,
+                content: {},
+            }
+
+            const sub = new Subscription('streamId', 0, 'apiKey', (content, receivedMsg) => {
+                assert.equal(content, msg.content)
+                assert.deepEqual(msg, receivedMsg)
+                done()
+            })
+
+            sub.handleMessage(msg)
+        })
+
+        it('emits "gap" if a gap is detected', (done) => {
+            const msg1 = {
+                offset: 1,
+                previousOffset: null,
+                content: {},
+            }
+
+            const msg4 = {
+                offset: 4,
+                previousOffset: 3,
+                content: {},
+            }
+
+            const sub = new Subscription('streamId', 0, 'apiKey', sinon.stub())
+            sub.on('gap', (from, to) => {
+                assert.equal(from, 2)
+                assert.equal(to, 3)
+                done()
+            })
+
+            sub.handleMessage(msg1)
+            sub.handleMessage(msg4)
+        })
+    })
+
+    describe('handleError', () => {
+        it('emits an error event', (done) => {
+            const err = new Error('Test error')
+            const sub = new Subscription('streamId', 0, 'apiKey', sinon.stub().throws('Msg handler should not be called!'))
+            sub.on('error', (thrown) => {
+                assert(err === thrown)
+                done()
+            })
+            sub.handleError(err)
+        })
+
+        it('marks the message as received if an InvalidJsonError occurs, and continue normally on next message', (done) => {
+            const sub = new Subscription('streamId', 0, 'apiKey', (content, msg) => {
+                if (msg.offset === 3) {
+                    done()
+                }
+            })
+
+            sub.on('gap', sinon.stub().throws('Should not emit gap!'))
+
+            const msg1 = {
+                offset: 1,
+                previousOffset: null,
+                content: {},
+            }
+            const msg3 = {
+                offset: 3,
+                previousOffset: 2,
+                content: {},
+            }
+
+            // Receive msg1 successfully
+            sub.handleMessage(msg1)
+
+            // Get notified of an invalid message
+            const err = new InvalidJsonError('streamId', 'invalid json', 'test error msg', 2, 1)
+            sub.handleError(err)
+
+            // Receive msg3 successfully
+            sub.handleMessage(msg3)
+        })
+    })
+})


### PR DESCRIPTION
The `lastReceivedOffset` variable in `Subscription` is now updated after an `InvalidJsonError` is encountered to avoid doomed-to-fail resends triggered by the gapfill protocol. This allows the flow of messages to continue normally after the message that failed to parse.