### PR TITLE
[CORE-1575] streamr-client: Use npm prepack hook instead of prepare hook in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production webpack",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "dev": "webpack --progress --colors --watch",
     "eslint": "eslint src/** test/**",
     "test": "jest",


### PR DESCRIPTION
Npm prepare hook runs also on local `npm install` and we don't want to run `npm run build` before installing the deps. Prepack hook only runs before `npm pack` or `npm publish`