### PR TITLE
Empty strings are *given* auth params

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -8,10 +8,10 @@ export default class Session {
         this.options = options || {}
         this.state = Session.State.LOGGED_OUT
 
-        if (this.options.privateKey) {
+        if (typeof this.options.privateKey !== 'undefined') {
             const account = web3.eth.accounts.privateKeyToAccount(this.options.privateKey)
             this.loginFunction = async () => this._client.loginWithChallengeResponse((d) => account.sign(d).signature, account.address)
-        } else if (this.options.provider) {
+        } else if (typeof this.options.provider !== 'undefined') {
             const w3 = new Web3(this.options.provider)
             this.loginFunction = async () => {
                 const accounts = await w3.eth.getAccounts()
@@ -21,9 +21,9 @@ export default class Session {
                 }
                 return this._client.loginWithChallengeResponse((d) => w3.eth.personal.sign(d, address), address)
             }
-        } else if (this.options.apiKey) {
+        } else if (typeof this.options.apiKey !== 'undefined') {
             this.loginFunction = async () => this._client.loginWithApiKey(this.options.apiKey)
-        } else if (this.options.username && this.options.password) {
+        } else if (typeof this.options.username !== 'undefined' && typeof this.options.password !== 'undefined') {
             this.loginFunction = async () => this._client.loginWithUsernamePassword(this.options.username, this.options.password)
         } else {
             if (!this.options.sessionToken) {

--- a/test/integration/Session.test.js
+++ b/test/integration/Session.test.js
@@ -1,14 +1,7 @@
-import assert from 'assert'
-
 import StreamrClient from '../../src'
 import config from './config'
 
 describe('Session', () => {
-    let clientApiKey
-    let clientWrongApiKey
-    let clientPrivateKey
-    let clientUsernamePassword
-
     const createClient = (opts = {}) => new StreamrClient({
         url: config.websocketUrl,
         restUrl: config.restUrl,
@@ -17,46 +10,63 @@ describe('Session', () => {
         ...opts,
     })
 
-    beforeAll(() => {
-        clientApiKey = createClient({
-            auth: {
-                apiKey: 'tester1-api-key',
-            },
-        })
-        clientWrongApiKey = createClient({
-            auth: {
-                apiKey: 'wrong-api-key',
-            },
-        })
-        clientPrivateKey = createClient({
-            auth: {
-                privateKey: '348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709',
-            },
-        })
-        clientUsernamePassword = createClient({
-            auth: {
-                username: 'tester2@streamr.com',
-                password: 'tester2',
-            },
-        })
-    })
-
     describe('Token retrievals', () => {
-        it('should get token from API key', () => clientApiKey.session.getSessionToken()
-            .then((sessionToken) => {
-                assert(sessionToken)
-            }))
-        it('should fail to get token from wrong API key', () => clientWrongApiKey.session.getSessionToken()
-            .catch((err) => {
-                assert(err)
-            }))
-        it('should get token from private key', () => clientPrivateKey.session.getSessionToken()
-            .then((sessionToken) => {
-                assert(sessionToken)
-            }))
-        it('should get token from username/password', () => clientUsernamePassword.session.getSessionToken()
-            .then((sessionToken) => {
-                assert(sessionToken)
-            }))
+        it('gets the token using api key', async () => {
+            expect.assertions(1)
+            await expect(createClient({
+                auth: {
+                    apiKey: 'tester1-api-key',
+                },
+            }).session.getSessionToken()).resolves.toBeTruthy()
+        })
+
+        it('fails when the used api key is ivalid', async () => {
+            expect.assertions(1)
+            await expect(createClient({
+                auth: {
+                    apiKey: 'wrong-api-key',
+                },
+            }).session.getSessionToken()).rejects.toMatchObject({
+                message: expect.stringMatching(/invalid api key/i),
+            })
+        })
+
+        it('gets the token using private key', async () => {
+            expect.assertions(1)
+            await expect(createClient({
+                auth: {
+                    privateKey: '348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709',
+                },
+            }).session.getSessionToken()).resolves.toBeTruthy()
+        })
+
+        it('gets the token using username and password', async () => {
+            expect.assertions(1)
+            await expect(createClient({
+                auth: {
+                    username: 'tester2@streamr.com',
+                    password: 'tester2',
+                },
+            }).session.getSessionToken()).resolves.toBeTruthy()
+        })
+
+        it('fails when the used username and password is invalid', async () => {
+            expect.assertions(1)
+            await expect(createClient({
+                auth: {
+                    username: 'tester2@streamr.com',
+                    password: 'WRONG',
+                },
+            }).session.getSessionToken()).rejects.toMatchObject({
+                message: expect.stringMatching(/invalid username or password/i),
+            })
+        })
+
+        it('gets no token (undefined) when the auth object is empty', async () => {
+            expect.assertions(1)
+            await expect(createClient({
+                auth: {},
+            }).session.getSessionToken()).resolves.toBeUndefined()
+        })
     })
 })


### PR DESCRIPTION
I was trying to use the client to login with username and password. I "entered" empty values for both and it didn't tell me anything is wrong, but did not proceed either. The `auth` option gets populated with `{ username: ‘’, password: ‘’ }` but it behaves like it's empty.

In this PR I address that issue. I also update integration tests for `Session`; make them more compact.

Hope you like it! 💃 